### PR TITLE
feat: persist initiative order across sessions + fix COM STA

### DIFF
--- a/src/UI.py
+++ b/src/UI.py
@@ -159,6 +159,11 @@ class App(tk.Tk):
             cfg.get("char_af_overrides", "")
         )
 
+        _raw_order = cfg.get("char_order", "")
+        self._saved_pseudo_order: list[str] = (
+            [p.strip() for p in _raw_order.split(",") if p.strip()] if _raw_order else []
+        )
+
         self._prev_hwnd: int | None = None
 
         _raw_skip = cfg.get("char_skip_names", "[]") or "[]"
@@ -525,14 +530,18 @@ class App(tk.Tk):
     def refresh_characters(self):
         if not WIN32_OK:
             return
-        windows   = get_dofus_windows()
-        win_map   = {h: p for h, p in windows}
-        known     = set(win_map.keys())
-        new_order = [(h, win_map[h]) for h, _ in self._char_order if h in known]
-        existing  = {h for h, _ in new_order}
+        windows    = get_dofus_windows()
+        win_map    = {h: p for h, p in windows}
+        known      = set(win_map.keys())
+        first_load = not self._char_order
+        new_order  = [(h, win_map[h]) for h, _ in self._char_order if h in known]
+        existing   = {h for h, _ in new_order}
         for h, p in windows:
             if h not in existing:
                 new_order.append((h, p))
+        if first_load and self._saved_pseudo_order:
+            rank = {p: i for i, p in enumerate(self._saved_pseudo_order)}
+            new_order.sort(key=lambda x: rank.get(x[1], len(self._saved_pseudo_order)))
         self._char_order = new_order
         self._rebuild_char_list()
         if hasattr(self, "_af_chars_container"):
@@ -642,6 +651,11 @@ class App(tk.Tk):
         if self._drag_idx is not None:
             self._drag_idx = None
             self._rebuild_char_list()
+            self._persist_char_order()
+
+    def _persist_char_order(self):
+        self._saved_pseudo_order = [p for _, p in self._char_order]
+        self._persist_config()
 
     def _save_order(self):
         if not self._char_order:
@@ -872,6 +886,7 @@ class App(tk.Tk):
             self._welcome_shown, self._char_skip_names,
             self.remove_notif_var.get(),
             self.maximize_on_launch_var.get(),
+            self._saved_pseudo_order,
         ))
 
     # ── Gestion des exclusions de roulement ───────────────────────────────────
@@ -1223,6 +1238,8 @@ class App(tk.Tk):
         pass
 
     def _run_async_loop(self):
+        import ctypes
+        ctypes.windll.ole32.CoInitializeEx(None, 0x2)  # COINIT_APARTMENTTHREADED
         self._loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self._loop)
         try:
@@ -1231,6 +1248,7 @@ class App(tk.Tk):
             self.after(0, self.log_msg, f"Erreur fatale : {e}", "error")
         finally:
             self._loop.close()
+            ctypes.windll.ole32.CoUninitialize()
 
     async def _listen(self):
         listener = winman.UserNotificationListener.current

--- a/src/logic.py
+++ b/src/logic.py
@@ -23,6 +23,8 @@ import time
 import sys as _sys
 if getattr(_sys, "frozen", False):
     ICON_PATH = os.path.join(_sys._MEIPASS, "icon.ico")
+    _log_path = os.path.join(os.path.dirname(_sys.executable), "dracoon.log")
+    _sys.stderr = open(_log_path, "w", buffering=1, encoding="utf-8")
 else:
     ICON_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "icon.ico")
 
@@ -364,7 +366,8 @@ def _unhook_all():
 def _build_config(shortcut_next, shortcut_prev, shortcut_back,
                   char_af_overrides=None, shortcut_main=None, char_main=None,
                   welcome_shown=False, char_skip_names=None,
-                  remove_notif=False, maximize_on_launch=True) -> dict:    
+                  remove_notif=False, maximize_on_launch=True,
+                  char_order=None) -> dict:
     return {
         "shortcut_next":     shortcut_next,
         "shortcut_prev":     shortcut_prev,
@@ -376,7 +379,8 @@ def _build_config(shortcut_next, shortcut_prev, shortcut_back,
         "char_skip_names":   json.dumps(sorted(char_skip_names), ensure_ascii=False)
                              if char_skip_names else "[]",
         "remove_notif":        "1" if remove_notif else "0",
-        "maximize_on_launch":  "1" if maximize_on_launch else "0",                     
+        "maximize_on_launch":  "1" if maximize_on_launch else "0",
+        "char_order":          ",".join(char_order) if char_order else "",
     }
 
 


### PR DESCRIPTION
## Résumé

Ce PR apporte deux nouvelles fonctionnalités et un correctif de build, développés et testés sur Python 3.13 / Windows 11.

---

### 1. Persistence de l'ordre d'initiative

Avant ce changement, l'ordre des personnages dans l'onglet **Personnages** était perdu à chaque redémarrage de l'application. L'utilisateur devait réordonner manuellement ses personnages à chaque lancement.

Désormais, dès qu'un drag & drop est effectué, l'ordre est automatiquement sauvegardé dans le registre Windows (clé \char_order\ dans \HKCU\Software\DofusRetro\). Au prochain lancement, l'ordre est restauré avant l'affichage de la liste.

**Fichiers modifiés :**
- \src/logic.py\ — \_build_config\ accepte un nouveau paramètre \char_order\
- \src/UI.py\ — chargement de \char_order\ dans \__init__\, restauration dans \efresh_characters\, sauvegarde automatique dans \_drag_end\ via un nouveau \_persist_char_order()\

---

### 2. Correction COM STA pour \UserNotificationListener\

Sur certaines configurations Windows 11, \UserNotificationListener\ échoue silencieusement ou lève des erreurs COM car le thread qui l'utilise n'est pas initialisé en mode STA (*Single-Threaded Apartment*).

Le thread \_run_async_loop\ appelle maintenant \CoInitializeEx(None, COINIT_APARTMENTTHREADED)\ avant de démarrer la boucle asyncio, puis \CoUninitialize()\ à la fin. Cela rend la détection de notifications plus fiable sans impacter les performances.

---

### 3. Correction de la boîte d'erreur en mode compilé (PyInstaller)

Lors d'un build PyInstaller avec \--windowed\, toute exception non interceptée qui écrit sur \stderr\ provoque l'affichage d'une boîte de dialogue Windows *« Failed to execute script »*, sans aucun détail utile.

Quand l'application est lancée en mode compilé (\sys.frozen == True\), \stderr\ est maintenant redirigé vers un fichier \dracoon.log\ placé à côté de l'exécutable. Cela supprime la boîte d'erreur et permet de diagnostiquer les problèmes après distribution.

---

## Plan de test

- [ ] Réordonner les personnages par drag & drop, fermer et relancer → ordre restauré
- [ ] Vérifier dans \egedit\ que \HKCU\Software\DofusRetro\char_order\ contient les pseudos dans le bon ordre
- [ ] Tester AutoFocus sur une machine sans session COM active → pas d'erreur COM
- [ ] Builder avec PyInstaller \--windowed\ et vérifier qu'aucune boîte d'erreur n'apparaît au démarrage